### PR TITLE
Fixed nr of issues and PRs for the docs

### DIFF
--- a/achievements/statistics.md
+++ b/achievements/statistics.md
@@ -27,10 +27,10 @@
 
 |                          | Total |
 | ------------------------ | ----- |
-| Merged Pull Requests     |  34   |
+| Merged Pull Requests     |  35   |
 | Proposed Pull Requests   |  17   |
-| Closed Issues            |   8   |
-| New Issues               |   2   |
+| Closed Issues            |  11   |
+| New Issues               |   3   |
 
 ## Diversity
 


### PR DESCRIPTION
According to https://github.com/symfony/symfony-docs/issues?q=is%3Aissue+label%3A%22%E2%AD%90%EF%B8%8F+EU-FOSSA+Hackathon%22+is%3Aopen , more issues were closed and proposed for the docs than what was reported here. Also, a quick grep on merge commits from the weekend revealed we merged 35 PRs (our merge tool sometimes closes a PR, so GitHub's statistics don't always match)